### PR TITLE
게시판 api 만들기 - DataREST 적용 및 테스트 정의

### DIFF
--- a/board-project/build.gradle
+++ b/board-project/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/board-project/src/main/java/com/min/board/repository/ArticleCommentRepository.java
+++ b/board-project/src/main/java/com/min/board/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.min.board.repository;
 
 import com.min.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment,Long> {
 }

--- a/board-project/src/main/java/com/min/board/repository/ArticleRepository.java
+++ b/board-project/src/main/java/com/min/board/repository/ArticleRepository.java
@@ -3,7 +3,9 @@ package com.min.board.repository;
 import com.min.board.domain.Article;
 import com.min.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/board-project/src/main/resources/application.yml
+++ b/board-project/src/main/resources/application.yml
@@ -21,3 +21,6 @@ spring:
       hibernate.default_batch_fetch_size: 100
   h2.console.enabled: true
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/board-project/src/test/java/com/min/board/controller/DataRestTest.java
+++ b/board-project/src/test/java/com/min/board/controller/DataRestTest.java
@@ -1,0 +1,86 @@
+package com.min.board.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional      //기본적으로 rollback으로 실행됨
+public class DataRestTest {
+    private final MockMvc mvc;
+
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void given_whenRequestingArticles_thenTest() throws Exception {
+        //Given
+
+        //When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void given_whenRequestingArticle_thenTest() throws Exception {
+        //Given
+
+        //When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void given_whenRequestingArticleCommentsFromArticle_thenTest() throws Exception {
+        //Given
+
+        //When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+    }
+
+    @DisplayName("[api]댓글 리스트 조회")
+    @Test
+    void given_whenRequestingArticleComments_thenTest() throws Exception {
+        //Given
+
+        //When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void given_whenRequestingArticleComment_thenTest() throws Exception {
+        //Given
+
+        //When & Then
+        mvc.perform(MockMvcRequestBuilders.get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Sprign Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크하는 통합 테스트 작성