### PR TITLE
게시판 서비스 뷰 기능 구현 - 테스트까지

### DIFF
--- a/board-project/src/main/java/com/min/board/controller/HomeController.java
+++ b/board-project/src/main/java/com/min/board/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.min.board.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+    @GetMapping("/")
+    public String root() {
+        return "forward:/articles";
+    }
+}

--- a/board-project/src/main/java/com/min/board/domain/type/SearchType.java
+++ b/board-project/src/main/java/com/min/board/domain/type/SearchType.java
@@ -1,0 +1,5 @@
+package com.min.board.domain.type;
+
+public enum SearchType {
+    TITLE, CONTENT, ID,NICKNAME,HASHTAG
+}

--- a/board-project/src/main/java/com/min/board/dto/ArticleCommentDto.java
+++ b/board-project/src/main/java/com/min/board/dto/ArticleCommentDto.java
@@ -1,0 +1,45 @@
+package com.min.board.dto;
+
+import com.min.board.domain.Article;
+import com.min.board.domain.ArticleComment;
+
+import java.time.LocalDateTime;
+
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+        Long id,
+        Long articleId,
+        UserAccountDto userAccountDto,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleCommentDto toDto(ArticleComment entity) {
+        return new ArticleCommentDto(
+                entity.getId(),
+                entity.getArticle().getId(),
+                UserAccountDto.toDto(entity.getUserAccount()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public ArticleComment toEntity(Article entity) {
+        return ArticleComment.of(
+                entity,
+                content,
+                userAccountDto.toEntity()
+        );
+    }
+
+}

--- a/board-project/src/main/java/com/min/board/dto/ArticleDto.java
+++ b/board-project/src/main/java/com/min/board/dto/ArticleDto.java
@@ -1,0 +1,52 @@
+package com.min.board.dto;
+
+import com.min.board.domain.Article;
+import com.min.board.domain.UserAccount;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleDto(
+        Long id,
+        UserAccountDto userAccountDto,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {     //
+
+    public static ArticleDto of(Long id, UserAccountDto userAccountDto, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleDto(id, userAccountDto, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleDto toDto(Article entity) {     //엔티티를 입력하면 DTO로 변환
+        return new ArticleDto(
+                entity.getId(),
+                UserAccountDto.toDto(entity.getUserAccount()),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getHashtag(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public Article toEntity() {         //Dto를 엔티티로
+                                        //Article은 Dto의 변경점을 모르기 때문에 Dto의 변화가 Article의 영향을 주지 않는다.
+        return Article.of(
+                userAccountDto.toEntity(),
+                title,
+                content,
+                hashtag
+        );
+    }
+
+
+}
+
+

--- a/board-project/src/main/java/com/min/board/dto/ArticleWithCommentsDto.java
+++ b/board-project/src/main/java/com/min/board/dto/ArticleWithCommentsDto.java
@@ -1,0 +1,43 @@
+package com.min.board.dto;
+
+import com.min.board.domain.Article;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ArticleWithCommentsDto(
+        Long id,
+        UserAccountDto userAccountDto,
+        Set<ArticleCommentDto> articleCommentDtos,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static ArticleWithCommentsDto of(Long id, UserAccountDto userAccountDto, Set<ArticleCommentDto> articleCommentDtos, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleWithCommentsDto(id, userAccountDto, articleCommentDtos, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleWithCommentsDto toDto(Article entity) {
+        return new ArticleWithCommentsDto(
+                entity.getId(),
+                UserAccountDto.toDto(entity.getUserAccount()),
+                entity.getArticleComments().stream()
+                        .map(ArticleCommentDto::toDto)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getHashtag(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+}

--- a/board-project/src/main/java/com/min/board/dto/UserAccountDto.java
+++ b/board-project/src/main/java/com/min/board/dto/UserAccountDto.java
@@ -1,0 +1,48 @@
+package com.min.board.dto;
+
+import com.min.board.domain.UserAccount;
+
+import java.time.LocalDateTime;
+
+public record UserAccountDto(
+        Long id,
+        String userId,
+        String userPassword,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+
+) {
+    public static UserAccountDto of(Long id, String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(id, userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static UserAccountDto toDto(UserAccount entity) {
+        return new UserAccountDto(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public UserAccount toEntity() {
+        return UserAccount.of(
+                userId,
+                userPassword,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/board-project/src/main/java/com/min/board/dto/response/ArticleCommentResponse.java
+++ b/board-project/src/main/java/com/min/board/dto/response/ArticleCommentResponse.java
@@ -1,0 +1,35 @@
+package com.min.board.dto.response;
+
+import com.min.board.dto.ArticleCommentDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleCommentResponse(
+        Long id,
+        String content,
+        LocalDateTime createdAt,
+        String email,
+        String nickname
+) implements Serializable {
+
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    }
+
+    public static ArticleCommentResponse from(ArticleCommentDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userAccountDto().userId();
+        }
+
+        return new ArticleCommentResponse(
+                dto.id(),
+                dto.content(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname
+        );
+    }
+
+}

--- a/board-project/src/main/java/com/min/board/dto/response/ArticleResponse.java
+++ b/board-project/src/main/java/com/min/board/dto/response/ArticleResponse.java
@@ -1,0 +1,38 @@
+package com.min.board.dto.response;
+
+import com.min.board.dto.ArticleDto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleResponse(
+        Long id,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String email,
+        String nickname
+) {
+
+    public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
+        return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);
+    }
+
+    public static ArticleResponse from(ArticleDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {   ////문자열이 비어있거나, 빈 공백이면 true
+            nickname = dto.userAccountDto().email();
+        }
+        return new ArticleResponse(
+                dto.id(),
+                dto.title(),
+                dto.content(),
+                dto.hashtag(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname
+        );
+    }
+
+}

--- a/board-project/src/main/java/com/min/board/dto/response/ArticleWithCommentResponse.java
+++ b/board-project/src/main/java/com/min/board/dto/response/ArticleWithCommentResponse.java
@@ -1,0 +1,45 @@
+package com.min.board.dto.response;
+
+import com.min.board.dto.ArticleWithCommentsDto;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ArticleWithCommentResponse(
+        Long id,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String email,
+        String nickname,
+        Set<ArticleCommentResponse> articleCommentResponses
+)  {
+
+    public static ArticleWithCommentResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    }
+
+    public static ArticleWithCommentResponse from(ArticleWithCommentsDto dto) {
+        String nickname = dto.userAccountDto().nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = dto.userAccountDto().userId();
+        }
+
+        return new ArticleWithCommentResponse(
+                dto.id(),
+                dto.title(),
+                dto.content(),
+                dto.hashtag(),
+                dto.createdAt(),
+                dto.userAccountDto().email(),
+                nickname,
+                dto.articleCommentDtos().stream()
+                        .map(ArticleCommentResponse::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+        );
+    }
+
+}

--- a/board-project/src/main/java/com/min/board/repository/ArticleCommentRepository.java
+++ b/board-project/src/main/java/com/min/board/repository/ArticleCommentRepository.java
@@ -11,11 +11,15 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+import java.util.List;
+
 @RepositoryRestResource
 public interface ArticleCommentRepository extends
         JpaRepository<ArticleComment,Long>,
         QuerydslPredicateExecutor<ArticleComment>,
         QuerydslBinderCustomizer<QArticleComment> {
+
+    List<ArticleComment> findByArticle_Id(Long articleId);      //Article 엔티티에 Id로 찾는다.
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         bindings.excludeUnlistedProperties(true);        //선택적으로 검색이 가능하도록 하는 것

--- a/board-project/src/main/java/com/min/board/repository/ArticleRepository.java
+++ b/board-project/src/main/java/com/min/board/repository/ArticleRepository.java
@@ -6,6 +6,8 @@ import com.min.board.domain.QArticle;
 import com.min.board.domain.QArticleComment;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
@@ -18,8 +20,10 @@ public interface ArticleRepository extends
         QuerydslPredicateExecutor<Article>,
         QuerydslBinderCustomizer<QArticle>
 {
+    Page<Article> findByTitle(String title, Pageable pageable);
+
     @Override
-    default void customize(QuerydslBindings bindings, QArticle root) {
+            default void customize(QuerydslBindings bindings, QArticle root) {
         bindings.excludeUnlistedProperties(true);        //선택적으로 검색이 가능하도록 하는 것
         bindings.including(root.title, root.content, root.hashtag, root.createdAt, root.createdBy);
         bindings.bind(root.title).first(StringExpression::containsIgnoreCase);

--- a/board-project/src/main/java/com/min/board/service/ArticleCommentService.java
+++ b/board-project/src/main/java/com/min/board/service/ArticleCommentService.java
@@ -1,0 +1,33 @@
+package com.min.board.service;
+
+import com.min.board.dto.ArticleCommentDto;
+import com.min.board.repository.ArticleCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentService {
+    private final ArticleCommentRepository articleCommentRepository;
+
+
+    @Transactional(readOnly = true)
+    public List<ArticleCommentDto> searchArticleComments(Long articleId) {
+        return List.of();
+    }
+
+    public void saveArticleComment(ArticleCommentDto dto) {
+        
+    }
+
+    public void deleteArticleComment(Long articleCommentId) {
+    }
+
+    public void updateArticleComment(ArticleCommentDto dto) {
+    }
+
+}

--- a/board-project/src/main/java/com/min/board/service/ArticleService.java
+++ b/board-project/src/main/java/com/min/board/service/ArticleService.java
@@ -1,0 +1,37 @@
+package com.min.board.service;
+
+import com.min.board.domain.type.SearchType;
+import com.min.board.dto.ArticleDto;
+import com.min.board.dto.ArticleWithCommentsDto;
+import com.min.board.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ArticleService {
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
+        return Page.empty();
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleWithCommentsDto getArticle(long articleId) {
+        return null;
+    }
+
+    public void saveArticle(ArticleDto dto) {
+    }
+
+    public void updateArticle(ArticleDto dto) {
+    }
+
+    public void deleteArticle(long articleId) {
+    }
+}

--- a/board-project/src/main/resources/application.yml
+++ b/board-project/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
+    open-in-view: false
   h2.console.enabled: true
   sql.init.mode: always
 

--- a/board-project/src/test/java/com/min/board/controller/HomeControllerTest.java
+++ b/board-project/src/test/java/com/min/board/controller/HomeControllerTest.java
@@ -1,0 +1,36 @@
+package com.min.board.controller;
+
+import com.min.board.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(HomeController.class)
+class HomeControllerTest {
+    private final MockMvc mvc;
+
+    public HomeControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Test
+    void givenNothing_whenRequestingRootPage_thenRedirectsToArticlePage() throws Exception {
+        mvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/articles"))
+                .andExpect(forwardedUrl("/articles"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+
+}

--- a/board-project/src/test/java/com/min/board/service/ArticleCommentServiceTest.java
+++ b/board-project/src/test/java/com/min/board/service/ArticleCommentServiceTest.java
@@ -1,0 +1,187 @@
+package com.min.board.service;
+
+import com.min.board.domain.Article;
+import com.min.board.domain.ArticleComment;
+import com.min.board.domain.UserAccount;
+import com.min.board.dto.ArticleCommentDto;
+import com.min.board.dto.UserAccountDto;
+import com.min.board.repository.ArticleCommentRepository;
+import com.min.board.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 댓글")
+@ExtendWith(MockitoExtension.class)
+class ArticleCommentServiceTest {
+
+    @InjectMocks private ArticleCommentService sut;
+
+    @Mock private ArticleRepository articleRepository;
+    @Mock private ArticleCommentRepository articleCommentRepository;
+
+    @DisplayName("게시글 ID로 조회하면, 해당하는 댓글 리스트를 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticleComments_thenReturnsArticleComments() {
+        // Given
+        Long articleId = 1L;
+        ArticleComment expected = createArticleComment("content");
+        given(articleCommentRepository.findByArticle_Id(articleId)).willReturn(List.of(expected));
+
+        // When
+        List<ArticleCommentDto> actual = sut.searchArticleComments(articleId);
+
+        // Then
+        assertThat(actual)
+                .hasSize(1)
+                .first().hasFieldOrPropertyWithValue("content", expected.getContent());
+        then(articleCommentRepository).should().findByArticle_Id(articleId);
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")
+    @Test
+    void givenArticleCommentInfo_whenSavingArticleComment_thenSavesArticleComment() {
+        // Given
+        ArticleCommentDto dto = createArticleCommentDto("댓글");
+        given(articleRepository.getReferenceById(dto.articleId())).willReturn(createArticle());
+        given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(null);
+
+        // When
+        sut.saveArticleComment(dto);
+
+        // Then
+        then(articleRepository).should().getReferenceById(dto.articleId());
+        then(articleCommentRepository).should().save(any(ArticleComment.class));
+    }
+
+    @DisplayName("댓글 저장을 시도했는데 맞는 게시글이 없으면, 경고 로그를 찍고 아무것도 안 한다.")
+    @Test
+    void givenNonexistentArticle_whenSavingArticleComment_thenLogsSituationAndDoesNothing() {
+        // Given
+        ArticleCommentDto dto = createArticleCommentDto("댓글");
+        given(articleRepository.getReferenceById(dto.articleId())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.saveArticleComment(dto);
+
+        // Then
+        then(articleRepository).should().getReferenceById(dto.articleId());
+        then(articleCommentRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 수정한다.")
+    @Test
+    void givenArticleCommentInfo_whenUpdatingArticleComment_thenUpdatesArticleComment() {
+        // Given
+        String oldContent = "content";
+        String updatedContent = "댓글";
+        ArticleComment articleComment = createArticleComment(oldContent);
+        ArticleCommentDto dto = createArticleCommentDto(updatedContent);
+        given(articleCommentRepository.getReferenceById(dto.id())).willReturn(articleComment);
+
+        // When
+        sut.updateArticleComment(dto);
+
+        // Then
+        assertThat(articleComment.getContent())
+                .isNotEqualTo(oldContent)
+                .isEqualTo(updatedContent);
+        then(articleCommentRepository).should().getReferenceById(dto.id());
+    }
+
+    @DisplayName("없는 댓글 정보를 수정하려고 하면, 경고 로그를 찍고 아무 것도 안 한다.")
+    @Test
+    void givenNonexistentArticleComment_whenUpdatingArticleComment_thenLogsWarningAndDoesNothing() {
+        // Given
+        ArticleCommentDto dto = createArticleCommentDto("댓글");
+        given(articleCommentRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.updateArticleComment(dto);
+
+        // Then
+        then(articleCommentRepository).should().getReferenceById(dto.id());
+    }
+
+    @DisplayName("댓글 ID를 입력하면, 댓글을 삭제한다.")
+    @Test
+    void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
+        // Given
+        Long articleCommentId = 1L;
+        willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+
+        // When
+        sut.deleteArticleComment(articleCommentId);
+
+        // Then
+        then(articleCommentRepository).should().deleteById(articleCommentId);
+    }
+
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserAccountDto(),
+                content,
+                LocalDateTime.now(),
+                "kdm",
+                LocalDateTime.now(),
+                "kdm"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                1L,
+                "kdm",
+                "password",
+                "kdm@mail.com",
+                "Kdm",
+                "This is memo",
+                LocalDateTime.now(),
+                "kdm",
+                LocalDateTime.now(),
+                "kdm"
+        );
+    }
+
+    private ArticleComment createArticleComment(String content) {
+        return ArticleComment.of(
+                Article.of(createUserAccount(), "title", "content", "hashtag"),
+                content,
+                createUserAccount()
+        );
+    }
+
+    private UserAccount createUserAccount() {
+        return UserAccount.of(
+                "uno",
+                "password",
+                "uno@email.com",
+                "Uno",
+                null
+        );
+    }
+
+    private Article createArticle() {
+        return Article.of(
+                createUserAccount(),
+                "title",
+                "content",
+                "#java"
+        );
+    }
+
+}

--- a/board-project/src/test/java/com/min/board/service/ArticleServiceTest.java
+++ b/board-project/src/test/java/com/min/board/service/ArticleServiceTest.java
@@ -1,0 +1,217 @@
+package com.min.board.service;
+
+
+import com.min.board.domain.Article;
+import com.min.board.domain.UserAccount;
+import com.min.board.domain.type.SearchType;
+import com.min.board.dto.ArticleDto;
+import com.min.board.dto.ArticleWithCommentsDto;
+import com.min.board.dto.UserAccountDto;
+import com.min.board.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 게시글")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    @InjectMocks private ArticleService sut;
+
+    @Mock private ArticleRepository articleRepository;
+
+    @DisplayName("검색어 없이 게시글을 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticles_thenReturnsArticlePage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findAll(pageable)).willReturn(Page.empty());
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(null, null, pageable);
+
+        // Then
+        assertThat(articles).isEmpty();
+        then(articleRepository).should().findAll(pageable);
+    }
+
+    @DisplayName("검색어와 함께 게시글을 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenSearchParameters_whenSearchingArticles_thenReturnsArticlePage() {
+        // Given
+        SearchType searchType = SearchType.TITLE;
+        String searchKeyword = "title";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByTitle(searchKeyword, pageable)).willReturn(Page.empty());
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(searchType, searchKeyword, pageable);
+
+        // Then
+        assertThat(articles).isEmpty();
+        then(articleRepository).should().findByTitle(searchKeyword, pageable);
+    }
+
+    @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticle_thenReturnsArticle() {
+        // Given
+        Long articleId = 1L;
+        Article article = createArticle();
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+
+        // When
+        ArticleWithCommentsDto dto = sut.getArticle(articleId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("title", article.getTitle())
+                .hasFieldOrPropertyWithValue("content", article.getContent())
+                .hasFieldOrPropertyWithValue("hashtag", article.getHashtag());
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("없는 게시글을 조회하면, 예외를 던진다.")
+    @Test
+    void givenNonexistentArticleId_whenSearchingArticle_thenThrowsException() {
+        // Given
+        Long articleId = 0L;
+        given(articleRepository.findById(articleId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getArticle(articleId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("게시글이 없습니다 - articleId: " + articleId);
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("게시글 정보를 입력하면, 게시글을 생성한다.")
+    @Test
+    void givenArticleInfo_whenSavingArticle_thenSavesArticle() {
+        // Given
+        ArticleDto dto = createArticleDto();
+        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
+
+        // When
+        sut.saveArticle(dto);
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 수정 정보를 입력하면, 게시글을 수정한다.")
+    @Test
+    void givenModifiedArticleInfo_whenUpdatingArticle_thenUpdatesArticle() {
+        // Given
+        Article article = createArticle();
+        ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#springboot");
+        given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+
+        // When
+        sut.updateArticle(dto);
+
+        // Then
+        assertThat(article)
+                .hasFieldOrPropertyWithValue("title", dto.title())
+                .hasFieldOrPropertyWithValue("content", dto.content())
+                .hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
+        then(articleRepository).should().getReferenceById(dto.id());
+    }
+
+    @DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
+    @Test
+    void givenNonexistentArticleInfo_whenUpdatingArticle_thenLogsWarningAndDoesNothing() {
+        // Given
+        ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#springboot");
+        given(articleRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.updateArticle(dto);
+
+        // Then
+        then(articleRepository).should().getReferenceById(dto.id());
+    }
+
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다")
+    @Test
+    void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
+        // Given
+        Long articleId = 1L;
+        willDoNothing().given(articleRepository).deleteById(articleId);
+
+        // When
+        sut.deleteArticle(1L);
+
+        // Then
+        then(articleRepository).should().deleteById(articleId);
+    }
+
+
+    private UserAccount createUserAccount() {
+        return UserAccount.of(
+                "kdm",
+                "password",
+                "kdm@email.com",
+                "Dongmin",
+                null
+        );
+    }
+
+    private Article createArticle() {
+        return Article.of(
+                createUserAccount(),
+                "title",
+                "content",
+                "#java"
+        );
+    }
+
+    private ArticleDto createArticleDto() {
+        return createArticleDto("title", "content", "#java");
+    }
+
+    private ArticleDto createArticleDto(String title, String content, String hashtag) {
+        return ArticleDto.of(1L,
+                createUserAccountDto(),
+                title,
+                content,
+                hashtag,
+                LocalDateTime.now(),
+                "kdm",
+                LocalDateTime.now(),
+                "kdm");
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                1L,
+                "kdm",
+                "password",
+                "kdm@mail.com",
+                "Dongmin",
+                "This is memo",
+                LocalDateTime.now(),
+                "kdm",
+                LocalDateTime.now(),
+                "kdm"
+        );
+    }
+
+}


### PR DESCRIPTION
다음의 기능을 테스트로 표현

- 게시글 검색하면 게시글 리스트 반환
- 게시글을 ID로 조회
- 게시글 생성
- 게시글 수정
- 게시글 삭제

필요한 dto 와 enum을 함께 작성했는데, 추후에 수정할 수도 있고
평소와는 다르게 dto를 컨트롤러로 가는 객체에 경우 따로 response Dto를 만들어서 컨트롤러는 dto의 정보를 알지 못하게 작성