### PR TITLE
페이지네이션 + 정렬 오류 해결

### DIFF
--- a/board-project/src/main/resources/templates/articles/index.th.xml
+++ b/board-project/src/main/resources/templates/articles/index.th.xml
@@ -55,19 +55,19 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'previous'"
-                  th:href="@{/articles(page=${articles.number - 1},searchType=${param.searchType},searchValue=${param.searchValue})}"
+                  th:href="@{/articles(page=${articles.number - 1},searchType=${param.searchType},searchValue=${param.searchValue},sort=${param.sort})}"
                   th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
             />
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                 <attr sel="a"
                       th:text="${pageNumber + 1}"
-                      th:href="@{/articles(page=${pageNumber},searchType=${param.searchType},searchValue=${param.searchValue})}"
+                      th:href="@{/articles(page=${pageNumber},searchType=${param.searchType},searchValue=${param.searchValue},sort=${param.sort})}"
                       th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                 />
             </attr>
             <attr sel="li[2]/a"
                   th:text="'next'"
-                  th:href="@{/articles(page=${articles.number + 1},searchType=${param.searchType},searchValue=${param.searchValue})}"
+                  th:href="@{/articles(page=${articles.number + 1},searchType=${param.searchType},searchValue=${param.searchValue},sort=${param.sort})}"
                   th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>


### PR DESCRIPTION
정렬 후 페이지를 넘길 경우 페이지가 초기화되는 오류를 해결 했다.

이는 url에 쿼리 파라미터에 sort에 관한 메서드를 타임리프에 추가해주지 않아서 생기는 오류였다.

This closes #35 